### PR TITLE
Fixed directory watching

### DIFF
--- a/scss/tool.py
+++ b/scss/tool.py
@@ -96,8 +96,8 @@ The location of the generated CSS can be set using a colon:
 
         if os.path.isdir(self):
             for f in os.listdir(self):
-                if os.path.isfile(f) and f.endswitch('.scss'):
-                    path = os.path.join(self, f)
+                path = os.path.join(self, f)
+                if os.path.isfile(path) and f.endswith('.scss'):
                     tpath = os.path.join(target or self, f[:-5] + '.css')
                     files.append([ path, tpath, 0 ])
         else:


### PR DESCRIPTION
Watching a directory did not work (checking path of file with isfile() was not called with absolute path and name.endswith had a type -> endswitch).
