### PR TITLE
Fix str.name bug in Stylesheet.load()

### DIFF
--- a/scss/parser.py
+++ b/scss/parser.py
@@ -317,7 +317,7 @@ class Stylesheet(object):
             path = os.path.abspath(f.name)
 
         else:
-            path = os.path.abspath(f.name)
+            path = os.path.abspath(f)
             f = open(f)
 
         cache_path = os.path.splitext(path)[0] + '.ccss'


### PR DESCRIPTION
This is the error I get when I try to load a stylesheet with a file path:

  File "/usr/local/lib/python2.6/dist-packages/scss-0.8.50-py2.6.egg/scss/parser.py", line 320, in load
    path = os.path.abspath(f.name)
AttributeError: 'str' object has no attribute 'name'
