### PR TITLE
Fix broken invert function

### DIFF
--- a/scss/function.py
+++ b/scss/function.py
@@ -264,11 +264,14 @@ def _invert(color, **kwargs):
         The red, green, and blue values are inverted, while the opacity is left alone.
     """
     col = ColorValue(color)
-    c = col.value
-    c[0] = 255.0 - c[0]
-    c[1] = 255.0 - c[1]
-    c[2] = 255.0 - c[2]
-    return col
+    args = [
+            255.0 - col.value[0],
+            255.0 - col.value[1],
+            255.0 - col.value[2],
+            col.value[3],
+        ]
+    inverted = ColorValue(args)
+    return inverted
 
 def _adjust_lightness(color, amount, **kwargs):
     return hsl_op(OPRT['+'], color, 0, 0, amount)

--- a/scss/tests/__init__.py
+++ b/scss/tests/__init__.py
@@ -15,6 +15,7 @@ def all_tests_suite():
         'scss.tests.test_for',
         'scss.tests.test_scss',
         'scss.tests.test_files',
+        'scss.tests.test_color_functions',
     ])
 
 

--- a/scss/tests/test_color_functions.py
+++ b/scss/tests/test_color_functions.py
@@ -1,0 +1,44 @@
+import unittest
+
+from scss.parser import Stylesheet
+
+def verify_testcases(func):
+    """Runs the output of the function through SCSS and compares output.
+
+    To use: Write a function that returns a list of tuples, where the first
+    element of the tuple is SCSS code and the second element the expected
+    output. When you place this decorator around your function it will take the
+    SCSS code, run the parser over it and assert the output equals the expected
+    output."""
+
+    def assert_testcases(self, *args, **kwargs):
+        for (testcase, expected_output) in func(self, *args, **kwargs):
+            out = self.parser.loads(testcase)
+            self.assertEqual(expected_output, out)
+    return assert_testcases
+
+class TestSCSS( unittest.TestCase ):
+    """Test color functions
+
+    """
+    def setUp(self):
+        self.parser = Stylesheet(options=dict(compress=True))
+
+    @verify_testcases
+    def test_invert(self):
+        return [
+            ('invert(#000)', '#fff'),
+            ('invert(#fff)', '#000'),
+            ('invert(#567)', '#a98'),
+            ('invert(invert(#123456))', '#123456'),
+            ('invert(rgba(100, 110, 120, 0.7))', 'rgba(155,145,135,0.70)'),
+            ('invert(hsla(0, 50%, 50%, 0.7))',   'rgba(63,191,191,0.70)'),
+        ]
+    
+    @verify_testcases
+    def test_adjust_lightness(self):
+        # First example is taken from
+        # http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html
+        return [
+            ('adjust-lightness(#800, 20%)', '#e00'),
+        ]


### PR DESCRIPTION
The invert-function in trunk is broken because it tries to assign to a tuple:

```
(scss)quinox@tikko ~/tmp/scss $ echo 'invert(#567)' | scss
Traceback (most recent call last):
  File "/home/quinox/tmp/scss/bin/scss", line 8, in <module>
    load_entry_point('scss==0.8.71', 'console_scripts', 'scss')()
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/tool.py", line 185, in main
    outfile.write(s.load(infile))
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/parser.py", line 353, in load
    return ''.join(map(str, nodes))
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/value.py", line 100, in __str__
    return str(self.value)
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/control.py", line 66, in value
    first = first.value
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/control.py", line 88, in value
    return func(*params, **kwargs)
  File "/home/quinox/tmp/scss/lib/python2.7/site-packages/scss/function.py", line 268, in _invert
    c[0] = 255.0 - c[0]
TypeError: 'tuple' object does not support item assignment
```

I fixed it by creating a new ColorValue object instead. I've added a few testcases for the invert-function and one for the adjust-lightness function as well.
